### PR TITLE
fix(postcss): allow default postcss settings to be overridden.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Add target files here. These can be anything that Webpack can understand. By def
 
 The option compileIndividualFiles will create one less file per source files. 
 
+#### PostCSS
+This setting enables postcss-loader. For this to work, you need to create a postcss.config.js file in your project root. [Read more about how to configure Post CSS here](https://github.com/postcss/postcss-loader).
+
 ### Env
 Settings for ports etc
 

--- a/configs/projectoptions.yml
+++ b/configs/projectoptions.yml
@@ -120,19 +120,8 @@ compilation:
   # If set to true, assets specified in the assets array (see below), will be copied during build
   copyAssetsToFolder: false
 
-  # Settings for css-minification
-  minifycss:
-    report: min
-    level: 2
-
-  # Settings for PostCSS
-  postcss:
-    map: true
-    processors:
-    - name: autoprefixer
-      options:
-        browsers:
-        - last 2 versions
+  # Use PostCSS? Requires separate PostCSS config.
+  postcss: false
 
 
 #-------------------------------------------------------------------------------

--- a/dvm-build/schema/config-schema.js
+++ b/dvm-build/schema/config-schema.js
@@ -46,6 +46,7 @@ const ConfigSchema = new SchemaObject({
         sourceMaps: Boolean,
         emitCssCopies: Boolean,
         copyAssetsToFolder: Boolean,
+        postcss: Boolean,
 
         // This will be populated dynamically
         entry: 'any'

--- a/dvm-build/utils/cssfile-rulegenerator.js
+++ b/dvm-build/utils/cssfile-rulegenerator.js
@@ -60,11 +60,7 @@ module.exports = function()
 					loader: "css-loader" // 2. Translates CSS into CommonJS
 				},
 				{
-					loader:'postcss-loader',
-					options:
-					{
-						plugins:[require('autoprefixer')]
-					}
+					loader:'postcss-loader'
 				},
 				{
 					loader: loader_specs[ls_key].loader, // 1. Preprocess

--- a/dvm-build/utils/cssfile-rulegenerator.js
+++ b/dvm-build/utils/cssfile-rulegenerator.js
@@ -49,6 +49,10 @@ module.exports = function()
 
 	} // for
 
+	let postCssLoader = [];
+	if (dvmConfig.compilation.postcss === true)
+		postCssLoader = [{loader: 'postcss-loader'}];
+
 	// Create neccesary loaders
 	for (ls_key in loader_specs)
 	{
@@ -59,9 +63,7 @@ module.exports = function()
 				use: [{
 					loader: "css-loader" // 2. Translates CSS into CommonJS
 				},
-				{
-					loader:'postcss-loader'
-				},
+				...postCssLoader,
 				{
 					loader: loader_specs[ls_key].loader, // 1. Preprocess
 					options: loader_specs[ls_key].options

--- a/dvm-build/webpack/webpack.patternlibrary.base.conf.js
+++ b/dvm-build/webpack/webpack.patternlibrary.base.conf.js
@@ -94,9 +94,6 @@ module.exports = {
 							"sourceMap": false,
 							"import": false
 						}
-					},
-					{
-						"loader": "postcss-loader"
 					}
 				]
 			},

--- a/dvm-build/webpack/webpack.patternlibrary.base.conf.js
+++ b/dvm-build/webpack/webpack.patternlibrary.base.conf.js
@@ -96,13 +96,7 @@ module.exports = {
 						}
 					},
 					{
-						"loader": "postcss-loader",
-						"options":
-						{
-							"ident": "postcss",
-							"plugins": require('autoprefixer'),
-							"sourceMap": false
-						}
+						"loader": "postcss-loader"
 					}
 				]
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9330,11 +9330,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -9347,15 +9349,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -9458,7 +9463,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -9468,6 +9474,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -9480,17 +9487,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -9507,6 +9517,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -9579,7 +9590,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -9589,6 +9601,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -9694,6 +9707,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
BREAKING CHANGE: autoprefixer is no longer enabled by default. It can be
enabled by using a postcss.config.js file in your project.